### PR TITLE
Station Name Change

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -35,7 +35,7 @@ entities:
   - uid: 2173
     components:
     - type: MetaData
-      name: Frontier Outpost
+      name: Flooftier Outpost
     - type: Transform
       pos: 0.121950805,-0.15609694
       parent: 5691

--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -1,6 +1,6 @@
 - type: gameMap
-  id: Frontier
-  mapName: 'Frontier Outpost'
+  id: Flooftier
+  mapName: 'Flooftier Outpost'
   mapPath: /Maps/_NF/Outpost/frontier.yml
   minPlayers: 0
   maxPlayers: 100
@@ -11,7 +11,7 @@
       stationProto: StandardFrontierStation
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Frontier Outpost'
+          mapNameTemplate: 'Flooftier Outpost'
 #          nameGenerator:
 #            !type:NanotrasenNameGenerator
 #            prefixCreator: '14'


### PR DESCRIPTION
Changed Frontier Outpost to Flooftier Outpost

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the name of the station from Frontier Outpost to Flooftier Outpost

## Why / Balance
It's nice

## How to test
Leave the station and check the IFF

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Changed station name to Flooftier Outpost
- remove: Name of station as Frontier Outpost
-->
